### PR TITLE
 Modifying url retrieval in order to manage WordPress installations on subdirectories

### DIFF
--- a/js/wp_bootstrap_polylang.js
+++ b/js/wp_bootstrap_polylang.js
@@ -37,7 +37,7 @@
         $changelang += '<ul class="dropdown-menu" role="menu">';
 
         $.each(lang, function(key, value) {
-            $changelang += '<li class="lang-item ' + key + '"><a class="nav-link" target="_self" href="' + siteurl + '/' + key + '/' + pageId[key] + '" title="' + value + '">' + value + '</a></li>';
+            $changelang += '<li class="lang-item ' + key + '"><a target="_self" href="' + siteurl + '/' + key + '/' + pageId[key] + '" title="' + value + '">' + value + '</a></li>';
         });
 
         $changelang += '</ul></li>';

--- a/js/wp_bootstrap_polylang.js
+++ b/js/wp_bootstrap_polylang.js
@@ -18,6 +18,8 @@
     var pageId = pllVars.postID;
     var $changelang = "";
     var lang = {};
+    var siteurl = pllVars.url;
+
 
     if (!$navbar.find($navitem).hasClass("pll-lang")) {
 
@@ -35,7 +37,7 @@
         $changelang += '<ul class="dropdown-menu" role="menu">';
 
         $.each(lang, function(key, value) {
-            $changelang += '<li class="lang-item ' + key + '"><a target="_self" href="//' + window.location.host + '/' + key + '/' + pageId[key] + '" title="' + value + '">' + value + '</a></li>';
+            $changelang += '<li class="lang-item ' + key + '"><a class="nav-link" target="_self" href="' + siteurl + '/' + key + '/' + pageId[key] + '" title="' + value + '">' + value + '</a></li>';
         });
 
         $changelang += '</ul></li>';

--- a/wp_bootstrap_polylang.php
+++ b/wp_bootstrap_polylang.php
@@ -18,6 +18,8 @@ function wp_bootstrap_polylang() {
             $postID = $wp_query->post->ID;
             $postType = get_post_type($postID);
             $lang_list = array();
+            $url = site_url();
+
 
             $postTypes = array("page", "post");
 
@@ -45,7 +47,8 @@ function wp_bootstrap_polylang() {
 
             wp_enqueue_script('pll_nav', get_template_directory_uri() . '/assets/js/wp_bootstrap_polylang.js', array(), '1.2.4', true);
             wp_localize_script('pll_nav', 'pllVars', array(
-                    'postID' => $lang_list
+                    'postID' => $lang_list,
+                    'url' => $url
                 )
             );
         }


### PR DESCRIPTION
Using the `site_url()` method instead of `window.location.host`, installations of WordPress on subdirectories will forward to the correct link.